### PR TITLE
Fix resource warnings

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -30,13 +30,13 @@ install_manpage:
 # FIXME: Fix broken `ipc.Subprocess.wait`.
 .PHONY: test
 test:
-	$(PYTHON) -W ignore:ResourceWarning -m unittest discover --start-directory tests/
+	$(PYTHON) -m unittest discover --start-directory tests/
 
 # FIXME: Fix broken `ipc.Subprocess.wait`.
 .PHONY: update-coverage
 update-coverage:
 	coverage erase
-	$(PYTHON) -W ignore:ResourceWarning -m coverage run -m unittest discover --start-directory tests/
+	$(PYTHON) -m coverage run -m unittest discover --start-directory tests/
 	coverage report --include=ocrodjvu/*
 
 .PHONY: clean

--- a/ocrodjvu/cli/ocrodjvu.py
+++ b/ocrodjvu/cli/ocrodjvu.py
@@ -135,10 +135,10 @@ class InPlaceSaver(Saver):
     def save(self, document, pages, djvu_path, sed_file):
         sed_file_name = os.path.abspath(sed_file.name)
         djvu_path = os.path.abspath(djvu_path)
-        djvused = ipc.Subprocess(
-            ['djvused', '-s', '-f', sed_file_name, djvu_path],
-        )
-        djvused.wait()
+        with ipc.Subprocess(
+                ['djvused', '-s', '-f', sed_file_name, djvu_path],
+        ) as djvused:
+            djvused.wait()
 
 
 class DryRunSaver(Saver):


### PR DESCRIPTION
This fixes the previous resource warnings which would occur during runtime and when running the corresponding tests. Closes #3.

There are three main changes in this:

* Always use `ipc.Subprocess` as context manager to ensure automatic cleanup.
* Do not overwrite `stdout` and `stderr` on the subprocess with `StreamReader` instances, as this will fail on cleanup.
* Overwrite the context manager `__exit__` method to not call `wait()`, as we always call it and this would always lead to failing subprocess calls.