### PR TITLE
Subprocess without explicit wait()

### DIFF
--- a/ocrodjvu/cli/djvu2hocr.py
+++ b/ocrodjvu/cli/djvu2hocr.py
@@ -313,10 +313,7 @@ def main(argv=None):
                 ['djvused', '-e', 'n', os.path.abspath(options.path)],
                 stdout=ipc.PIPE,
         ) as djvused:
-            try:
-                n_pages = int(djvused.stdout.readline())
-            finally:
-                djvused.wait()
+            n_pages = int(djvused.stdout.readline())
         options.pages = range(1, n_pages + 1)
     page_iterator = iter(options.pages)
     sed_script = temporary.file(suffix='.djvused', mode='w+', encoding='UTF-8')
@@ -351,6 +348,5 @@ def main(argv=None):
             page_zone = Zone(page_text, page_size[1])
             process_page(page_zone, options)
         sys.stdout.write(HOCR_FOOTER)
-        djvused.wait()
 
 # vim:ts=4 sts=4 sw=4 et

--- a/ocrodjvu/cli/ocrodjvu.py
+++ b/ocrodjvu/cli/ocrodjvu.py
@@ -138,7 +138,7 @@ class InPlaceSaver(Saver):
         with ipc.Subprocess(
                 ['djvused', '-s', '-f', sed_file_name, djvu_path],
         ) as djvused:
-            djvused.wait()
+            pass
 
 
 class DryRunSaver(Saver):

--- a/ocrodjvu/cli/ocrodjvu.py
+++ b/ocrodjvu/cli/ocrodjvu.py
@@ -137,7 +137,8 @@ class InPlaceSaver(Saver):
         djvu_path = os.path.abspath(djvu_path)
         with ipc.Subprocess(
                 ['djvused', '-s', '-f', sed_file_name, djvu_path],
-        ) as djvused:
+        ):
+            # Implicitly call `wait()` on `__exit__`.
             pass
 
 

--- a/ocrodjvu/engines/cuneiform.py
+++ b/ocrodjvu/engines/cuneiform.py
@@ -159,7 +159,7 @@ class Engine(common.Engine):
                     stdin=ipc.DEVNULL,
                     stdout=ipc.DEVNULL,
             ) as worker:
-                worker.wait()
+                pass
             with open(hocr_file_name, 'r') as hocr_file:
                 return common.Output(
                     hocr_file.read(),

--- a/ocrodjvu/engines/cuneiform.py
+++ b/ocrodjvu/engines/cuneiform.py
@@ -158,7 +158,8 @@ class Engine(common.Engine):
                     ] + self.extra_args + [image.name],
                     stdin=ipc.DEVNULL,
                     stdout=ipc.DEVNULL,
-            ) as worker:
+            ):
+                # Implicitly call `wait()` on `__exit__`.
                 pass
             with open(hocr_file_name, 'r') as hocr_file:
                 return common.Output(

--- a/ocrodjvu/engines/gocr.py
+++ b/ocrodjvu/engines/gocr.py
@@ -127,18 +127,15 @@ class Engine(common.Engine):
                     stdout=ipc.DEVNULL,
                     stderr=ipc.PIPE,
             ) as gocr:
-                try:
-                    line = gocr.stderr.read()
-                    m = _VERSION_RE.search(line.decode('UTF-8'))
-                    if not m:
-                        raise errors.EngineNotFoundError(Engine.name)
-                    version = tuple(map(int, m.groups()))
-                    if version >= (0, 40):
-                        return
-                    else:
-                        raise errors.EngineNotFoundError(Engine.name)
-                finally:
-                    gocr.wait()
+                line = gocr.stderr.read()
+                m = _VERSION_RE.search(line.decode('UTF-8'))
+                if not m:
+                    raise errors.EngineNotFoundError(Engine.name)
+                version = tuple(map(int, m.groups()))
+                if version >= (0, 40):
+                    return
+                else:
+                    raise errors.EngineNotFoundError(Engine.name)
         except OSError:
             raise errors.EngineNotFoundError(Engine.name)
 
@@ -157,13 +154,10 @@ class Engine(common.Engine):
                 stdin=ipc.DEVNULL,
                 stdout=ipc.PIPE,
         ) as worker:
-            try:
-                return common.Output(
-                    worker.stdout.read(),
-                    format_='gocr.xml',
-                )
-            finally:
-                worker.wait()
+            return common.Output(
+                worker.stdout.read(),
+                format_='gocr.xml',
+            )
 
     def extract_text(self, stream, **kwargs):
         settings = ExtractSettings(**kwargs)

--- a/ocrodjvu/engines/ocrad.py
+++ b/ocrodjvu/engines/ocrad.py
@@ -166,13 +166,10 @@ class Engine(common.Engine):
                 stdout=ipc.PIPE,
         ) as worker:
             stdout = codecs.getreader(sys.stdout.encoding or locale.getpreferredencoding())(worker.stdout)
-            try:
-                return common.Output(
-                    stdout.read(),
-                    format_='orf',
-                )
-            finally:
-                worker.wait()
+            return common.Output(
+                stdout.read(),
+                format_='orf',
+            )
 
     def extract_text(self, stream, **kwargs):
         settings = ExtractSettings(**kwargs)

--- a/tests/test_djvu2hocr/test.py
+++ b/tests/test_djvu2hocr/test.py
@@ -50,9 +50,7 @@ class Djvu2hocrTestCase(TestCase):
         self.assertEqual(stdout.getvalue(), '')
 
     def test_version(self):
-        """
-        https://bugs.debian.org/573496
-        """
+        # https://bugs.debian.org/573496
         stdout = io.StringIO()
         stderr = io.StringIO()
         with contextlib.redirect_stdout(stdout), contextlib.redirect_stderr(stderr):

--- a/tests/test_ipc.py
+++ b/tests/test_ipc.py
@@ -47,10 +47,11 @@ class ExceptionsTestCase(TestCase):
 
 
 class InitExceptionTestCase(TestCase):
+    """
+    https://bugs.python.org/issue32490
+    """
+
     def test_init_exc(self):
-        """
-        https://bugs.python.org/issue32490
-        """
         prog = 'ocrodjvu-nonexistent'
         with self.assertRaises(EnvironmentError) as ecm:
             ipc.Subprocess([prog])

--- a/tests/test_ocrodjvu/test.py
+++ b/tests/test_ocrodjvu/test.py
@@ -38,9 +38,7 @@ class OcrodjvuTestCase(TestCase):
         self.assertNotEqual(stdout.getvalue(), '')
 
     def test_version(self):
-        """
-        https://bugs.debian.org/573496
-        """
+        # https://bugs.debian.org/573496
         stdout = io.StringIO()
         stderr = io.StringIO()
         with contextlib.redirect_stdout(stdout), contextlib.redirect_stderr(stderr):

--- a/tests/test_unicode_support.py
+++ b/tests/test_unicode_support.py
@@ -53,10 +53,8 @@ class WordBreakIteratorTestCase(TestCase):
         self.assertEqual(s[-1], len(TEXT))
 
     def test_en_simple(self):
-        """
         # Trigger reference-counting bug that was fixed in PyICU 1.0.1:
         # https://github.com/ovalhub/pyicu/commit/515e076682e29d806aeb5f6b1016b799d03d92a9
-        """
         icu = get_icu()
         self.assertIsNotNone(icu)
         t = list(word_break_iterator('eggs', icu.Locale('en')))


### PR DESCRIPTION
Attempt to use `ipc.Subprocess` without explicit `wait()` if possible. There are still some exceptions for Tesseract and Cuneiform which have not been migrated and require special handling, as we would need a bigger rewrite otherwise.